### PR TITLE
Potential fix for code scanning alert no. 198: Information exposure through an exception

### DIFF
--- a/src/routes/project_plants.py
+++ b/src/routes/project_plants.py
@@ -170,7 +170,8 @@ def add_multiple_plants_to_project(project_id):
                 results.append(project_plant.to_dict())
 
             except Exception as e:
-                errors.append({"plant_data": plant_data, "error": str(e)})
+                # Do not expose internal exception details; log if necessary
+                errors.append({"plant_data": plant_data, "error": "Failed to add plant due to internal error."})
 
         response = {
             "added_plants": results,


### PR DESCRIPTION
Potential fix for [https://github.com/HANSKMIEL/landscape-architecture-tool/security/code-scanning/198](https://github.com/HANSKMIEL/landscape-architecture-tool/security/code-scanning/198)

To fix the information exposure issue, we should ensure that the error message included in the API response for each failed plant addition does **not** leak stack traces or low-level server details. Instead of providing the raw exception text for each failed plant, we can return a generic error message (such as "Failed to add plant") or a more user-friendly, sanitized error. For anticipated validation errors (e.g., ValueError), we can include that message, but for generic exceptions, return only a generic message.

- Update the code block at line 172-174 inside the loop in `add_multiple_plants_to_project`.
- Replace `str(e)` in `errors.append` with a generic message, e.g. `"Internal error during plant addition"`. Optionally, if ValueError or a known validation error, include its message (this would require an isinstance check).
- Optionally, log the real exception internally for debugging purposes (already happens for outer exceptions on line 187).
- No changes needed outside the code snippet provided.
- No new dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
