### PR TITLE
Potential fix for code scanning alert no. 196: Information exposure through an exception

### DIFF
--- a/src/routes/reports.py
+++ b/src/routes/reports.py
@@ -4,7 +4,7 @@
 
 import io
 from datetime import UTC, datetime
-
+import logging
 from flask import Blueprint, jsonify, request, send_file
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4
@@ -385,7 +385,8 @@ def generate_business_summary_pdf(data):
         )
 
     except Exception as e:
-        return jsonify({"error": f"PDF generation failed: {e!s}"}), 500
+        logging.exception("Error generating business summary PDF")
+        return jsonify({"error": "Failed to generate PDF report. Please try again later."}), 500
 
 
 @reports_bp.route("/api/reports/project/<int:project_id>", methods=["GET"])


### PR DESCRIPTION
Potential fix for [https://github.com/HANSKMIEL/landscape-architecture-tool/security/code-scanning/196](https://github.com/HANSKMIEL/landscape-architecture-tool/security/code-scanning/196)

To fix the problem, replace the occurrence where the exception’s message is returned to the user with a generic error message. Internally, log the original exception (including the stack trace if desired), but never show it to the user directly. Specifically:

- On line 388 inside `generate_business_summary_pdf`, replace `return jsonify({"error": f"PDF generation failed: {e!s}"}), 500` with a response such as `return jsonify({"error": "Failed to generate PDF report. Please try again later."}), 500`.
- Add logging of the actual exception and stack trace on the server side using Python's standard `logging` module.
- Import the `logging` module if it’s not already imported in this file.

The changes include:
- Add an import statement for `import logging` at the top.
- Add a logging call (such as `logging.exception("Error generating business summary PDF")`) inside the exception handler.
- Replace the returned error to the user with a generic message.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
