### PR TITLE
Potential fix for code scanning alert no. 193: Information exposure through an exception

### DIFF
--- a/src/routes/plant_recommendations.py
+++ b/src/routes/plant_recommendations.py
@@ -286,7 +286,8 @@ def get_recommendation_history():
         )
 
     except Exception as e:
-        return jsonify({"error": f"Failed to get history: {e!s}"}), 500
+        logging.exception("Failed to get history")  # Log full stack trace for investigation
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 
 @plant_recommendations_bp.route("/api/plant-recommendations/export", methods=["POST"])


### PR DESCRIPTION
Potential fix for [https://github.com/HANSKMIEL/landscape-architecture-tool/security/code-scanning/193](https://github.com/HANSKMIEL/landscape-architecture-tool/security/code-scanning/193)

To fix this issue, the exception handler at the end of `get_recommendation_history` should return a generic error message to the user instead of the exception message (i.e., `"Failed to get history: {e!s}"`). The stack trace or error should be logged only on the server side for developers to investigate, using the existing `logging` module. The change is required only in the `except Exception as e` block for `get_recommendation_history` in `src/routes/plant_recommendations.py`.

Implementation steps:
- In the exception handler, replace the response body to use a generic message (e.g., `"An internal error has occurred."`).
- Log the full exception—including stack trace—to the server logs using `logging.exception` for traceability.
- You may need to ensure the logging import exists (it does).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
