### PR TITLE
Potential fix for code scanning alert no. 192: Information exposure through an exception

### DIFF
--- a/src/routes/plant_recommendations.py
+++ b/src/routes/plant_recommendations.py
@@ -225,8 +225,7 @@ def submit_feedback():
         return jsonify({"error": "Failed to save feedback"}), 404
 
     except Exception as e:
-        logging.exception("Failed to submit feedback")
-        return jsonify({"error": "Failed to submit feedback"}), 500
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 
 @plant_recommendations_bp.route("/api/plant-recommendations/history", methods=["GET"])

--- a/src/routes/plant_recommendations.py
+++ b/src/routes/plant_recommendations.py
@@ -225,7 +225,8 @@ def submit_feedback():
         return jsonify({"error": "Failed to save feedback"}), 404
 
     except Exception as e:
-        return jsonify({"error": f"Failed to submit feedback: {e!s}"}), 500
+        logging.exception("Failed to submit feedback")
+        return jsonify({"error": "Failed to submit feedback"}), 500
 
 
 @plant_recommendations_bp.route("/api/plant-recommendations/history", methods=["GET"])


### PR DESCRIPTION
Potential fix for [https://github.com/HANSKMIEL/landscape-architecture-tool/security/code-scanning/192](https://github.com/HANSKMIEL/landscape-architecture-tool/security/code-scanning/192)

To fix this problem, we should avoid exposing internal exception details to the user. Instead, log the exception details using the application's logging system, and return a generic error message in the API response. This ensures that potentially sensitive information stays server-side, while users only see a safe message. Specifically, in `src/routes/plant_recommendations.py`, within the `submit_feedback` function, we should update the exception handler on lines 227–228 to:
- Log the exception with `logging.exception` (which records a stack trace and error message).
- Return a generic message: `{"error": "Failed to submit feedback"}` without the details.

Add imports as needed if not already present (e.g., `import logging` is present).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
